### PR TITLE
Fix project output path

### DIFF
--- a/YSF.vcxproj
+++ b/YSF.vcxproj
@@ -84,7 +84,6 @@
       <OptimizeReferences>true</OptimizeReferences>
       <ImportLibrary>bin\win32\Release\YSF.lib</ImportLibrary>
       <ModuleDefinitionFile>YSF.def</ModuleDefinitionFile>
-      <OutputFile>C:\Users\Ati\Desktop\SERVER\plugins\YSF.dll</OutputFile>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;psapi.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention>false</DataExecutionPrevention>


### PR DESCRIPTION
This fixes a build error on Windows:

```
C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V120\Microsoft.CppBuild.targets(1235,5): error MSB3191: Unable to create directory "C:\Users\Ati\Desktop\SERVER\plugins". Access to the path 'C:\Users\Ati\Desktop\SERVER\plugins' is denied.
```

I don't know why the diff is so big, probably because of line endings. This commit only changes one line.
