### PR TITLE
Enable AttachPlayerObjectToPlayer

### DIFF
--- a/sampsvr_files/pawno/include/YSF.inc
+++ b/sampsvr_files/pawno/include/YSF.inc
@@ -278,7 +278,7 @@ native GetPlayerAttachedObject(playerid, index, &modelid, &bone = 0, &Float:fX =
 //native RemPlayerAttachedObjForPlayer(forplayerid, removefromplayerid, index);
 //native IsPlayerAttachedObjForPlayer(forplayerid, attachtoplayerid, index);
 
-//n_ative AttachPlayerObjectToPlayer(objectplayer, objectid, attachplayer, Float:OffsetX, Float:OffsetY, Float:OffsetZ, Float:rX, Float:rY, Float:rZ);
+native AttachPlayerObjectToPlayer(objectplayer, objectid, attachplayer, Float:OffsetX, Float:OffsetY, Float:OffsetZ, Float:rX, Float:rY, Float:rZ);
 native AttachPlayerObjectToObject(playerid, objectid, attachtoid, Float:OffsetX, Float:OffsetY, Float:OffsetZ, Float:RotX, Float:RotY, Float:RotZ, SyncRotation = 1);
 
 // RakNet ban functions


### PR DESCRIPTION
This enables declaration of AttachPlayerObjectToPlayer in .inc file, since the plugin implementation already exists for this function.

Also related to these ones:
https://github.com/samp-incognito/samp-streamer-plugin/issues/408
https://github.com/samp-incognito/samp-streamer-plugin/pull/490